### PR TITLE
Css improvement taro read page

### DIFF
--- a/src/components/TarotCard.tsx
+++ b/src/components/TarotCard.tsx
@@ -6,7 +6,7 @@ function TarotFront({
   onClick: () => void;
 }) {
   return (
-    <div onClick={onClick} className="w-[200px] m-2">
+    <div onClick={onClick} className="w-[150px] h-10 m-2 cursor-pointer">
       <img className="rounded-md shadow-md" src={imageSrc} />
     </div>
   );

--- a/src/pages/TarotRead.tsx
+++ b/src/pages/TarotRead.tsx
@@ -69,6 +69,7 @@ function TarotRead() {
   const tarotReadButtons = buttonInfo.map((cardRead) => {
     return (
       <Button
+      key={cardRead.buttonname}
         buttonName={cardRead.buttonname}
         onClick={() => getOneCard(cardRead.cardreadLength)}
       ></Button>
@@ -78,12 +79,11 @@ function TarotRead() {
   return (
     <div className="h-[1000px] flex flex-col justify-center items-center">
       <Button buttonName="Home" onClick={() => navigate("/")}></Button>
-
       <Button onClick={() => getOneCard} buttonName="Generate Tarot Read" />
       {tarotReadButtons}
-      <div className=" ">
+      <div className="w-9/12 contents">
         <img className=" max-w-6xl mb-[-600px] mr-6" src="/Art/matt.png"></img>
-        <div className=" flex justify-center ">{pullThreeCards}</div>
+        <div className=" flex justify-center  max-w-6xl mt-12 ">{pullThreeCards}</div>
         {showHide && randomTarotNumbers[0] !== 0 && (
           <div>
             <div className="mt-[-450px] flex flex-row mx-auto justify-center  ">


### PR DESCRIPTION
I modified the TaroRead page so the sets of card is centered over the image.(the matt)
Changed the size of the card so that when you select set of 5-3-9 the scroll does not grow
added  a key to the map  list of <Button> to remove the issue from the console 